### PR TITLE
Fix gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ dependencies {
     modImplementation("ace.actually.radios:radios-1.20.1:1.0.0")
 
     //implementation("org.maplibre:earcut4j:3.0.0")
+    additionalRuntimeClasspath("org.maplibre:earcut4j:3.0.0")
     jarJar(implementation("org.maplibre:earcut4j:3.0.0")) {
         version {
             strictly "[3.0.0,)"

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ legacyForge {
 }
 
 mixin {
+    add sourceSets.main, "mixins.shipwrights.genesis.refmap.json"
     config 'genesis.mixins.json' // This can be done for multiple configs
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'dev.architectury.loom' version '1.10-SNAPSHOT'
     id 'maven-publish'
+    id 'net.neoforged.moddev.legacyforge' version '2.0.137'
 }
 
 group = project.maven_group
@@ -10,14 +10,39 @@ base {
     archivesName = project.archives_name
 }
 
-loom {
-    silentMojangMappingsLicense()
+legacyForge {
+    version = forge_version
 
-    accessWidenerPath = file("src/main/resources/genesis.accesswidener")
+    validateAccessTransformers = true
 
-    forge {
-        mixinConfig 'genesis.mixins.json'
+    runs {
+        client {
+            client()
+        }
+        data {
+            data()
+        }
+        server {
+            server()
+        }
     }
+
+    mods {
+        testproject {
+            sourceSet sourceSets.main
+        }
+    }
+}
+
+mixin {
+    add sourceSets.main, 'mixins.genesis.refmap.json'
+    config 'genesis.mixins.json' // This can be done for multiple configs
+}
+
+jar {
+    manifest.attributes([
+            "MixinConfigs": "genesis.mixins.json"
+    ])
 }
 
 repositories {
@@ -52,40 +77,75 @@ repositories {
 }
 
 dependencies {
-    minecraft "net.minecraft:minecraft:$project.minecraft_version"
-    mappings loom.officialMojangMappings()
-    forge "net.minecraftforge:forge:$project.forge_version"
-
-    modImplementation(include("com.tterrag.registrate:Registrate:${registrate_version}"))
+    jarJar(modImplementation("com.tterrag.registrate:Registrate:${registrate_version}")) {
+        version {
+            strictly "[${registrate_version},)"
+            prefer "${registrate_version}"
+        }
+    }
 
     implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:0.5.0"))
     implementation("io.github.llamalad7:mixinextras-forge:0.5.0")
 
     compileOnly(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-common:0.3.6-beta.1"))
-    implementation(include("com.github.bawnorton.mixinsquared:mixinsquared-forge:0.3.6-beta.1"))
-
-    implementation "thedarkcolour:kotlinforforge:4.11.0"
-
-    implementation ("org.valkyrienskies.core:api:$vs_core_version")
-    implementation ("org.valkyrienskies.core:internal:$vs_core_version")
-    implementation ("org.valkyrienskies.core:util:$vs_core_version")
-    implementation ("org.valkyrienskies.core:impl:$vs_core_version")
+    jarJar(implementation("com.github.bawnorton.mixinsquared:mixinsquared-forge:0.3.6-beta.1")) {
+        version {
+            strictly "[0.3.6-beta.1,)"
+            prefer "0.3.6-beta.1"
+        }
+    }
 
 
-    modImplementation("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}") { transitive = false }
+    // region Valkyrien Skies
+    implementation("org.valkyrienskies.core:api:${vs_core_version}") { transitive = false
+        exclude group: 'org.joml', module: ''
+    }
+    implementation("org.valkyrienskies.core:internal:${vs_core_version}") { transitive = false
+        exclude group: 'org.joml', module: ''
+    }
+    implementation("org.valkyrienskies.core:util:${vs_core_version}") { transitive = false
+        exclude group: 'org.joml', module: ''
+    }
+    implementation("org.valkyrienskies.core:impl:${vs_core_version}") { transitive = false
+        exclude group: 'org.joml', module: ''
+    }
+    modApi("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}") { transitive = false
+        exclude group: 'org.valkyrienskies.core', module: ''
+    }
+    // endregion
+
+    // region VS deps
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.3"
+    compileOnly("org.joml:joml:1.10.4")
+    compileOnly("org.joml:joml-primitives:1.10.0")
+    modApi("thedarkcolour:kotlinforforge:4.11.0")
+    // endregion
 
     modImplementation("maven.modrinth:vlib:1.20.1-0.1.0+forge")
+
+    // For VLib
+    modRuntimeOnly("maven.modrinth:architectury-api:9.2.14+forge")
 
     modImplementation("maven.modrinth:curios:5.14.1+1.20.1")
     modImplementation("maven.modrinth:lodestonelib:1.20.1-1.6.4.1")
 
-    include(modImplementation("maven.modrinth:pehkui:3.8.2+1.20.1-forge"))
+    jarJar(modImplementation("maven.modrinth:pehkui:3.8.2+1.20.1-forge")) {
+        version {
+            strictly "[3.8.0,)"
+            prefer "3.8.2+1.20.1-forge"
+        }
+    }
+
     modImplementation("ace.actually.radios:radios-1.20.1:1.0.0")
 
-    implementation(include("org.maplibre:earcut4j:3.0.0"))
-    implementation("org.joml:joml-primitives:1.10.0")
+    jarJar(modImplementation("org.maplibre:earcut4j:3.0.0")) {
+        version {
+            strictly "[3.0.0,)"
+            prefer "3.0.0"
+        }
+    }
+
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.0")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     // Test dependencies
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
 
     modImplementation("ace.actually.radios:radios-1.20.1:1.0.0")
 
-    jarJar(modImplementation("org.maplibre:earcut4j:3.0.0")) {
+    jarJar(implementation("org.maplibre:earcut4j:3.0.0")) {
         version {
             strictly "[3.0.0,)"
             prefer "3.0.0"

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,8 @@ dependencies {
 
     // Test dependencies
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testImplementation("org.joml:joml:1.10.4")
+    testImplementation("org.joml:joml-primitives:1.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ repositories {
 }
 
 dependencies {
+    annotationProcessor("org.spongepowered:mixin:0.8.5:processor")
+
     jarJar(modImplementation("com.tterrag.registrate:Registrate:${registrate_version}")) {
         version {
             strictly "[${registrate_version},)"

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ legacyForge {
 }
 
 mixin {
-    add sourceSets.main, 'mixins.genesis.refmap.json'
     config 'genesis.mixins.json' // This can be done for multiple configs
 }
 
@@ -138,6 +137,7 @@ dependencies {
 
     modImplementation("ace.actually.radios:radios-1.20.1:1.0.0")
 
+    //implementation("org.maplibre:earcut4j:3.0.0")
     jarJar(implementation("org.maplibre:earcut4j:3.0.0")) {
         version {
             strictly "[3.0.0,)"
@@ -193,5 +193,12 @@ publishing {
         // Notice: This block does NOT have the same function as the block in the top level.
         // The repositories here will be used for publishing your artifact, not for
         // retrieving dependencies.
+    }
+}
+
+sourceSets {
+    test {
+        compileClasspath += sourceSets.main.compileClasspath
+        runtimeClasspath += sourceSets.main.runtimeClasspath
     }
 }

--- a/src/main/java/shipwrights/genesis/mixin/LevelChunkMixin.java
+++ b/src/main/java/shipwrights/genesis/mixin/LevelChunkMixin.java
@@ -1,7 +1,5 @@
 package shipwrights.genesis.mixin;
 
-import com.google.common.collect.Maps;
-import kotlin.reflect.jvm.internal.impl.descriptors.PackageFragmentProviderImpl;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.world.level.ChunkPos;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,5 @@
+public net.minecraft.world.level.levelgen.SurfaceRules$SurfaceRule
+public net.minecraft.world.level.levelgen.SurfaceRules$Context
+
+public net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper
+public net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper m_156449_(Lnet/minecraft/world/level/block/entity/TickingBlockEntity;)V #rebind

--- a/src/main/resources/genesis.accesswidener
+++ b/src/main/resources/genesis.accesswidener
@@ -1,6 +1,0 @@
-accessWidener   v2  named
-accessible class net/minecraft/world/level/levelgen/SurfaceRules$SurfaceRule
-accessible class net/minecraft/world/level/levelgen/SurfaceRules$Context
-
-accessible class net/minecraft/world/level/chunk/LevelChunk$RebindableTickingBlockEntityWrapper
-accessible method net/minecraft/world/level/chunk/LevelChunk$RebindableTickingBlockEntityWrapper rebind (Lnet/minecraft/world/level/block/entity/TickingBlockEntity;)V

--- a/src/main/resources/genesis.mixins.json
+++ b/src/main/resources/genesis.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "shipwrights.genesis.mixin",
+  "refmap": "mixins.shipwrights.genesis.refmap.json",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [


### PR DESCRIPTION
Fixes the gradle by switching to ModDevGradle, and doing all changes required for that.

This means that the dev runtime can now launch! As well as it still exporting a valid forge jar with all the same dependencies JiJ'd as before.