### PR TITLE
Add warp transition

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,8 @@ forge_version = 1.20.1-47.4.0
 vs2_version=2.4.10
 vs_core_version=1.1.0+1d4a7373e9
 
+# Makes MDG use parchment
+neoForge.parchment.minecraftVersion=1.20.1
+neoForge.parchment.mappingsVersion=2023.09.03
+
 registrate_version = MC1.20-1.3.3

--- a/src/main/java/shipwrights/genesis/client/ClientStorage.java
+++ b/src/main/java/shipwrights/genesis/client/ClientStorage.java
@@ -1,0 +1,24 @@
+package shipwrights.genesis.client;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+/**
+ * Rather sussy class to store global client variables, mostly used in mixins
+ */
+@OnlyIn(Dist.CLIENT)
+public class ClientStorage {
+    /**
+     * True for a couple of ticks while the player is entering or leaving the wormhole dimension.
+     * Used for {@link shipwrights.genesis.mixin.MinecraftMixin}.
+     * <br>
+     * Set to true by the Void engine in {@link shipwrights.genesis.content.blockentity.VoidEngineInterfaceBlockEntity#tick(Level, BlockPos, BlockState, BlockEntity)}
+     * <br>
+     * Set to false by {@link WarpLoadingMenu#onClose()}
+     */
+    public static boolean goingToFromWormhole = false;
+}

--- a/src/main/java/shipwrights/genesis/client/WarpLoadingMenu.java
+++ b/src/main/java/shipwrights/genesis/client/WarpLoadingMenu.java
@@ -1,0 +1,190 @@
+package shipwrights.genesis.client;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.ReceivingLevelScreen;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.util.FastColor;
+import net.minecraft.util.RandomSource;
+import org.joml.Matrix4f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// This class is mostly GPT'd (the visuals atleast), feel free to improve
+public class WarpLoadingMenu extends ReceivingLevelScreen {
+
+    private final int starBufferCount = 3;
+    private final List<VertexBuffer> starBuffers = new ArrayList<>(starBufferCount);
+
+    public WarpLoadingMenu() {
+        createStars();
+    }
+
+    private void createStars() {
+        starBuffers.forEach(VertexBuffer::close);
+        starBuffers.clear();
+
+        BufferBuilder bufferbuilder = Tesselator.getInstance().getBuilder();
+
+        for (int i = 0; i < starBufferCount; i++) {
+            VertexBuffer starBuffer = new VertexBuffer(VertexBuffer.Usage.STATIC);
+            BufferBuilder.RenderedBuffer renderedBuffer = drawStars(bufferbuilder, 10842L / (i + 4));
+            starBuffer.bind();
+            starBuffer.upload(renderedBuffer);
+            VertexBuffer.unbind();
+            starBuffers.add(starBuffer);
+        }
+    }
+
+
+    @Override
+    public void render(GuiGraphics g, int mouseX, int mouseY, float partialTicks) {
+        // Hide the crosshair
+        Minecraft.getInstance().options.hideGui = true;
+
+        renderBackground(g);
+
+        PoseStack poseStack = g.pose();
+
+        // Create a projection matrix similar to world rendering
+        Matrix4f projection = new Matrix4f().setPerspective(
+                (float) Math.toRadians(70),
+                (float) width / height,
+                0.05f,
+                1000f
+        );
+
+        float time = (System.currentTimeMillis() % 1000000L) / 1000f;
+        float speed = 60f;
+        float loopLength = 200f;
+        int layerCount = 3;
+        float fadeStart = 0.1f;  // start fading at 10% of loop
+        float fadeEnd   = 0.9f;  // fully invisible at 90% of loop
+
+        poseStack.pushPose();
+        poseStack.scale(10f, 10f, 10f);
+
+        for (int i = 0; i < layerCount; i++) {
+            poseStack.pushPose();
+
+            float z = (time * speed - i * (loopLength / layerCount)) % loopLength;
+
+            poseStack.translate(0, 0, z);
+
+            float t = (z % loopLength) / loopLength;
+
+            // map t to 0→1 inside fade window
+            float alpha;
+            if (t < fadeStart) {
+                alpha = 1f; // fully visible
+            } else if (t > fadeEnd) {
+                alpha = 0f; // fully invisible
+            } else {
+                // linear fade
+                alpha = 1f - (t - fadeStart) / (fadeEnd - fadeStart);
+            }
+
+            // Set alpha via RenderSystem color
+            RenderSystem.setShaderColor(1f, 1f, 1f, alpha);
+
+            render(poseStack, projection);
+
+            poseStack.popPose();
+        }
+
+        // reset color
+        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+        poseStack.popPose();
+
+        //super.render(g, mouseX, mouseY, partialTicks);
+    }
+
+    public void render(PoseStack poseStack, Matrix4f projectionMatrix) {
+        ShaderInstance shader = ShaderRegistry.WORMHOLE_SHADER.getInstance().get();
+
+        RenderSystem.setShader(() -> ShaderRegistry.WORMHOLE_SHADER.getInstance().get());
+
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.disableDepthTest();
+
+        for (VertexBuffer buffer : starBuffers) {
+            buffer.bind();
+            buffer.drawWithShader(poseStack.last().pose(), projectionMatrix, shader);
+        }
+
+        VertexBuffer.unbind();
+        RenderSystem.disableBlend();
+        RenderSystem.enableDepthTest();
+    }
+
+    private BufferBuilder.RenderedBuffer drawStars(BufferBuilder bufferbuilder, long seed) {
+        RandomSource randomsource = RandomSource.create(seed);
+        bufferbuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR_TEX);
+
+        for(int i = 0; i < 300; ++i) {
+            double d0 = (double)(randomsource.nextFloat() * 2.0F - 1.0F);
+            double d1 = (double)(randomsource.nextFloat() * 2.0F - 1.0F);
+            double d2 = (double)(randomsource.nextFloat() * 2.0F - 1.0F);
+            double d3 = (double)(15.5F + randomsource.nextFloat() * 12.5F);
+            double d4 = d0 * d0 + d1 * d1 + d2 * d2;
+            if (d4 < 1.0 && d4 > 0.01) {
+                d4 = 1.0 / Math.sqrt(d4);
+                d0 *= d4;
+                d1 *= d4;
+                d2 *= d4;
+                double d5 = d0 * 100.0;
+                double d6 = d1 * 100.0;
+                double d7 = d2 * 100.0;
+                double d8 = Math.atan2(d0, d2);
+                double d9 = Math.sin(d8);
+                double d10 = Math.cos(d8);
+                double d11 = Math.atan2(Math.sqrt(d0 * d0 + d2 * d2), d1);
+                double d12 = Math.sin(d11);
+                double d13 = Math.cos(d11);
+                double d14 = randomsource.nextDouble() * Math.PI * 2.0;
+                double d15 = Math.sin(d14);
+                double d16 = Math.cos(d14);
+
+                int color = randomsource.nextInt();
+
+                int r = (int) (FastColor.ARGB32.red(color) * 0.7);
+                int g = (int) (FastColor.ARGB32.green(color) * 0.7);
+                int b = (int) (FastColor.ARGB32.blue(color) * 0.7);
+                int a = FastColor.ARGB32.alpha(color);
+
+
+                for(int j = 0; j < 4; ++j) {
+                    double d17 = 0.0;
+                    double d18 = (double)((j & 2) - 1) * d3;
+                    double d19 = (double)((j + 1 & 2) - 1) * d3;
+                    double d21 = d18 * d16 - d19 * d15;
+                    double d22 = d19 * d16 + d18 * d15;
+                    double d23 = d21 * d12 + d17 * d13;
+                    double d24 = d17 * d12 - d21 * d13;
+                    double d25 = d24 * d9 - d22 * d10;
+                    double d26 = d22 * d9 + d24 * d10;
+
+                    // Map UV to match the quad vertex positions
+                    // d18 goes from -d3 to +d3, d19 goes from -d3 to +d3
+                    float u = ((j & 2) == 0) ? 0.0f : 1.0f;
+                    float v = ((j + 1 & 2) == 0) ? 1.0f : 0.0f;
+
+                    bufferbuilder.vertex(d5 + d25, d6 + d23, d7 + d26).color(r, g, b, a).uv(u, v).endVertex();
+                }
+            }
+        }
+
+        return bufferbuilder.end();
+    }
+
+    @Override
+    public void onClose() {
+        Minecraft.getInstance().options.hideGui = false;
+        ClientStorage.goingToFromWormhole = false;
+        super.onClose();
+    }
+}

--- a/src/main/java/shipwrights/genesis/content/blockentity/VoidEngineInterfaceBlockEntity.java
+++ b/src/main/java/shipwrights/genesis/content/blockentity/VoidEngineInterfaceBlockEntity.java
@@ -16,6 +16,7 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.EnergyStorage;
 import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.network.PacketDistributor;
 import org.joml.Quaterniond;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
@@ -24,10 +25,7 @@ import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import shipwrights.genesis.GenesisMod;
 import shipwrights.genesis.content.block.VoidCoreBlock;
-import shipwrights.genesis.networking.GenesisNetworking;
-import shipwrights.genesis.networking.StopVoidEngineStartSoundPacket;
-import shipwrights.genesis.networking.VoidEngineSoundPacket;
-import shipwrights.genesis.networking.WormholeTravelSoundPacket;
+import shipwrights.genesis.networking.*;
 import shipwrights.genesis.teleportation.DimensionTravelTeleporter;
 import shipwrights.genesis.teleportation.TravelDirection;
 
@@ -132,6 +130,11 @@ public class VoidEngineInterfaceBlockEntity extends BlockEntity {
                                 if (wormholeLevel != null) {
                                     // Teleport ship to wormhole - scale position down
 
+                                    GenesisNetworking.INSTANCE.send(
+                                            PacketDistributor.TRACKING_CHUNK.with(() -> level.getChunkAt(pos)),
+                                            new EnteringWarpPacket()
+                                    );
+
                                     Vector3dc targetPos = ship.getTransform().getPositionInWorld().mul(1 / 32.0, new Vector3d());
                                     DimensionTravelTeleporter.teleportShip((ServerShip) ship, TravelDirection.PLANET_TO_SPACE, (ServerLevel) level, wormholeLevel, targetPos, new Quaterniond());
 
@@ -155,6 +158,14 @@ public class VoidEngineInterfaceBlockEntity extends BlockEntity {
                                 if (returnLevel != null) {
                                     // Teleport ship back - scale position up
                                     Vector3dc targetPos = ship.getTransform().getPositionInWorld().mul(32.0, new Vector3d());
+
+                                    GenesisNetworking.INSTANCE.send(
+                                            PacketDistributor.TRACKING_CHUNK.with(() -> level.getChunkAt(pos)),
+                                            new EnteringWarpPacket()
+                                    );
+
+                                    GenesisNetworking.sendToAll(GenesisNetworking.INSTANCE, new WormholeTravelSoundPacket(pos));
+
                                     DimensionTravelTeleporter.teleportShip((ServerShip) ship, TravelDirection.SPACE_TO_PLANET, (ServerLevel) level, returnLevel, targetPos, new Quaterniond());
 
                                     //sendWormholeTravelPacket

--- a/src/main/java/shipwrights/genesis/mixin/MinecraftMixin.java
+++ b/src/main/java/shipwrights/genesis/mixin/MinecraftMixin.java
@@ -20,17 +20,6 @@ public abstract class MinecraftMixin {
     @Shadow
     static Minecraft instance;
 
-    @Shadow
-    public Screen screen;
-
-    /**
-     * Note: this is not up to date on actual dimension changes.
-     * We only update this from the dimension transfer screen, and
-     * only use it for the dimension transfer screen
-     */
-    @Unique
-    private ResourceLocation previousDim;
-
     // This is called twice.
     // Once on leaving the current level
     // And once when in the new level

--- a/src/main/java/shipwrights/genesis/mixin/MinecraftMixin.java
+++ b/src/main/java/shipwrights/genesis/mixin/MinecraftMixin.java
@@ -1,0 +1,54 @@
+package shipwrights.genesis.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ProgressScreen;
+import net.minecraft.client.gui.screens.ReceivingLevelScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import shipwrights.genesis.GenesisMod;
+import shipwrights.genesis.client.ClientStorage;
+import shipwrights.genesis.client.WarpLoadingMenu;
+
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+    @Shadow
+    static Minecraft instance;
+
+    @Shadow
+    public Screen screen;
+
+    /**
+     * Note: this is not up to date on actual dimension changes.
+     * We only update this from the dimension transfer screen, and
+     * only use it for the dimension transfer screen
+     */
+    @Unique
+    private ResourceLocation previousDim;
+
+    // This is called twice.
+    // Once on leaving the current level
+    // And once when in the new level
+    @Inject(
+            method = "setScreen",
+            at = @At("RETURN")
+    )
+    private void injectSetScreen(Screen s, CallbackInfo ci) {
+        // Prevent recursion
+        if (s instanceof WarpLoadingMenu) return;
+
+        if (s instanceof ReceivingLevelScreen || s instanceof ProgressScreen) {
+            if (instance.level == null) return;
+
+            if (ClientStorage.goingToFromWormhole) {
+                instance.setScreen(new WarpLoadingMenu());
+            }
+        }
+    }
+
+}

--- a/src/main/java/shipwrights/genesis/networking/EnteringWarpPacket.java
+++ b/src/main/java/shipwrights/genesis/networking/EnteringWarpPacket.java
@@ -1,0 +1,25 @@
+package shipwrights.genesis.networking;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+import shipwrights.genesis.client.ClientStorage;
+import shipwrights.genesis.client.WarpLoadingMenu;
+
+import java.util.function.Supplier;
+
+public class EnteringWarpPacket {
+
+    public static void encode(EnteringWarpPacket msg, FriendlyByteBuf buf) {}
+
+    public static EnteringWarpPacket decode(FriendlyByteBuf buf) {
+        return new EnteringWarpPacket();
+    }
+
+    public static void handle(EnteringWarpPacket msg, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            ClientStorage.goingToFromWormhole = true;
+        });
+        ctx.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/shipwrights/genesis/networking/GenesisNetworking.java
+++ b/src/main/java/shipwrights/genesis/networking/GenesisNetworking.java
@@ -69,5 +69,11 @@ public class GenesisNetworking {
                 .decoder(StarPropertiesSyncPacket::decode)
                 .consumerMainThread(StarPropertiesSyncPacket::handle)
                 .add();
+
+        INSTANCE.messageBuilder(EnteringWarpPacket.class, 6)
+                .encoder(EnteringWarpPacket::encode)
+                .decoder(EnteringWarpPacket::decode)
+                .consumerMainThread(EnteringWarpPacket::handle)
+                .add();
     }
 }

--- a/src/main/resources/genesis.mixins.json
+++ b/src/main/resources/genesis.mixins.json
@@ -5,9 +5,9 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
-    "ClientLevelMixin",
     "ChannelAccessor",
     "ChunkBorderRendererMixin",
+    "ClientLevelMixin",
     "DimensionSpecialEffectsManagerMixin",
     "EntityRenderDispatcherMixin",
     "FallingBlockRendererMixin",
@@ -16,6 +16,7 @@
     "GameRendererMixin",
     "HugeExplosionSeedParticleMixin",
     "LevelRendererMixin",
+    "MinecraftMixin",
     "ParticleEngineMixin",
     "ParticleMixin",
     "PehkuiEntityRenderDispatcherMixin",


### PR DESCRIPTION
Adds a custom transition when teleporting between the wormhole dimension and the space dimension, replacing the immersion breaking "loading terrain" screen.

This does not affect the "loading terrain" screen between any other dimension.

This PR also adds a gradle property to make MDG use parchment, so the minecraft parameters and variables should have names now.