### PR TITLE
Fix atmosphere rendering flickering when player is on planet

### DIFF
--- a/src/main/java/shipwrights/genesis/space/renderer/PlanetAtmosphereRenderer.java
+++ b/src/main/java/shipwrights/genesis/space/renderer/PlanetAtmosphereRenderer.java
@@ -152,11 +152,16 @@ public class PlanetAtmosphereRenderer implements CelestialRenderer {
 
         float outOverexposureCancel = 1.0f;
 
-        if(
-        Math.abs(testPos.x) < halfSize * relativeAtmosphereSize &&
-        Math.abs(testPos.y) < halfSize * relativeAtmosphereSize &&
-        Math.abs(testPos.z) < halfSize * relativeAtmosphereSize
-        ) {
+        // When the player is standing on this planet, they are always inside the atmosphere
+        // cube by definition. Using the testPos boundary check here causes flickering as the
+        // camera oscillates around the threshold (e.g. at higher altitudes or lower render
+        // distances), so we skip it and force the inside-atmosphere rendering mode instead.
+        boolean cameraInsideAtmosphere = (vantagePoint instanceof VantagePoint.OnCelestial oc && oc.celestial().equals(toRender))
+                || (Math.abs(testPos.x) < halfSize * relativeAtmosphereSize
+                    && Math.abs(testPos.y) < halfSize * relativeAtmosphereSize
+                    && Math.abs(testPos.z) < halfSize * relativeAtmosphereSize);
+
+        if (cameraInsideAtmosphere) {
             correctionDist = 1.001f;
         } else {
             outOverexposureCancel = 0.000000001f;


### PR DESCRIPTION
## Summary
Fixed visual flickering in planet atmosphere rendering when the player is standing on the planet surface, particularly noticeable at higher altitudes or lower render distances.

## Key Changes
- Added explicit check for when the camera is positioned on a celestial body to force inside-atmosphere rendering mode
- Refactored the atmosphere boundary detection into a named boolean variable (`cameraInsideAtmosphere`) for clarity
- The boundary check is now skipped when the player is on the planet, preventing camera oscillation around the threshold from causing flickering
- Added detailed comments explaining the flickering issue and the rationale for the fix

## Implementation Details
The fix recognizes that when a player is standing on a planet, they are by definition always inside the atmosphere cube. The previous implementation used a positional boundary check that could cause the camera to oscillate around the threshold, resulting in visual artifacts. The new logic explicitly checks if the vantage point is `OnCelestial` and matches the rendered planet, forcing the inside-atmosphere rendering mode in that case while maintaining the boundary check for external viewpoints.

https://claude.ai/code/session_016QFwM68bqUgso5RjoidXQk